### PR TITLE
feat: Use new integrate-shipyard action

### DIFF
--- a/.github/workflows/print-env-data.yml
+++ b/.github/workflows/print-env-data.yml
@@ -6,9 +6,9 @@ jobs:
     name: Fetch Shipyard Vars
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Fetch Shipyard Environment
-        uses: shipyard/github-action/fetch-shipyard-env@1.0.0
+        uses: actions/checkout@v3
+      - name: Integrate Shipyard
+        uses: shipyard/shipyard-action@1.0.0
         with:
           api-token: ${{ secrets.SHIPYARD_API_TOKEN }}
           timeout-minutes: "10"


### PR DESCRIPTION
- Update the GHA workflow to use the newer Shipyard GitHub action, as reflected by our docs and marketplace listing
- Bump checkout action to v3

