### PR TITLE
Fix: updated makefile to docker compose V2 syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,33 +3,33 @@ VOLUME=$(shell basename $(PWD))
 develop: clean build migrations.all run
 
 clean:
-	docker-compose rm -vf
+	docker compose rm -vf
 
 build:
-	docker-compose build
+	docker compose build
 
 run:
-	docker-compose up
+	docker compose up
 
 shell:
-	docker-compose run django \
+	docker compose run django \
 	  sh
 
 python-shell:
-	docker-compose run django \
+	docker compose run django \
 	  poetry run python src/manage.py shell
 
 postgres.data.delete: clean
 	docker volume rm $(VOLUME)_postgres
 
 postgres.start:
-	docker-compose up -d postgres
-	docker-compose exec postgres \
+	docker compose up -d postgres
+	docker compose exec postgres \
 	  sh -c 'while ! nc -z postgres 5432; do sleep 0.1; done'
 
 postgres-shell: postgres.start
 	docker exec -it $(VOLUME)_postgres_1 sh
 
 migrations.all: postgres.start
-	docker-compose run django \
+	docker compose run django \
 	  poetry run python src/manage.py migrate


### PR DESCRIPTION
**Description**
Makefile failing due to referencing V1 docker compose
V1 no longer supported by [Docker](https://docs.docker.com/compose/migrate/)

Issue
Closes #6 